### PR TITLE
Fix np.int issue for python 3.11

### DIFF
--- a/asciitable/core.py
+++ b/asciitable/core.py
@@ -776,7 +776,7 @@ class NumpyOutputter(BaseOutputter):
     default_masked_array = False
 
     if has_numpy:
-        default_converters = [convert_numpy(numpy.int),
+        default_converters = [convert_numpy(int),
                               convert_numpy(numpy.float),
                               convert_numpy(numpy.str)]
 


### PR DESCRIPTION
Fix issue with upgrading to python 3.11

> `np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
        The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
            https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations.